### PR TITLE
Remove utc and use local time: When time difference makes that convertin...

### DIFF
--- a/multipleDatePicker.js
+++ b/multipleDatePicker.js
@@ -204,7 +204,7 @@ angular.module('multipleDatePicker', [])
 
       /*Generate the calendar*/
       scope.generate = function(){
-        var previousDay = moment.utc(scope.month).date(0),
+        var previousDay = moment(scope.month).date(0),
           firstDayOfMonth = moment(scope.month).date(1),
           days = [],
           now = moment(),


### PR DESCRIPTION
Remove utc and use local time: When time difference makes that converting time to utc changes the day, which is all countries east of England, basically, then the day retrieved is the day before, the trick to retrieve the good day was to call toISOString on date. For example, my local time is GMT+01, if I call toISOString, I get the correct day, at 23h. 
