### PR TITLE
fix bower package name.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "MultipleDatePicker",
+  "name": "angular-multiple-date-picker",
   "version": "2.0.1",
   "authors": [
     "mgohin <mgohin@arca-computing.fr>"

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "mgohin <mgohin@arca-computing.fr>"
   ],
   "description": "Angular directive to show a calendar and select multiple dates",
-  "main": ["dist/multipleDatePicker.min.js", "dist/multiple-date-picker.css"],
+  "main": ["dist/multipleDatePicker.js", "dist/multiple-date-picker.css"],
   "keywords": [
     "angular",
     "directive",


### PR DESCRIPTION
The pull request fixes following bower warnings:

bower invalid-meta  The "name" is recommended to be lowercase, can contain digits, dots, dashes
bower invalid-meta  The "main" field cannot contain minified files
