### PR TITLE
toggleDay now compares days instead of times

### DIFF
--- a/multipleDatePicker.js
+++ b/multipleDatePicker.js
@@ -261,13 +261,12 @@
 
                         if (day.selectable && !prevented) {
                             day.mdp.selected = !day.mdp.selected;
-
                             if (day.mdp.selected) {
                                 scope.ngModel.push(day.date);
                             } else {
                                 var idx = -1;
                                 for (var i = 0; i < scope.ngModel.length; ++i) {
-                                    if (scope.ngModel[i].isSame(day.date)) {
+                                    if (scope.ngModel[i].isSame(day.date,'day')) {
                                         idx = i;
                                         break;
                                     }


### PR DESCRIPTION
I found a bug in my earlier pr. I accidentally removed the second argument to "isSame()", so moment was looking for identical times between the date objects. The functionality prior to my pr allowed for different times on the same day to trigger the change to ngModel. This pr resolves that issue.

Sorry :)