### PR TITLE
Fix invalid main file path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-require('./dist/multiple-date-picker');
+require('./dist/multipleDatePicker');
 module.exports = 'multipleDatePicker';


### PR DESCRIPTION
The path in `index.js` was obsolete, making module bundlers fail to properly import the package.

On a  side note, you should also consider renaming the `.css` and `.less` files as now it's pretty inconsistent.